### PR TITLE
Use a custom class for tags.

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ None yet.
 
 ```
 sudo apt install \
+    python3-frozendict \
     python3-mutagen
 ```
 

--- a/pepper_music_player/library/database.py
+++ b/pepper_music_player/library/database.py
@@ -107,11 +107,13 @@ class Database:
                     },
                 ).lastrowid
                 if isinstance(file_info, metadata.AudioFile):
-                    self._connection.executemany(
-                        """
-                        INSERT INTO AudioFileTag (file_id, tag_name, tag_value)
-                        VALUES (:file_id, :tag_name, :tag_value)
-                        """,
-                        (dict(file_id=file_id, tag_name=name, tag_value=value)
-                         for name, value in file_info.tags),
-                    )
+                    for tag_name, tag_values in file_info.tags.items():
+                        self._connection.executemany(
+                            """
+                            INSERT INTO AudioFileTag (
+                              file_id, tag_name, tag_value)
+                            VALUES (?, ?, ?)
+                            """,
+                            ((file_id, tag_name, tag_value)
+                             for tag_value in tag_values),
+                        )

--- a/pepper_music_player/library/database_test.py
+++ b/pepper_music_player/library/database_test.py
@@ -56,7 +56,9 @@ class DatabaseTest(unittest.TestCase):
     def test_insert_files_generic(self):
         self._database.insert_files((
             metadata.File(dirname='a', filename='b'),
-            metadata.AudioFile(dirname='c', filename='d', tags=()),
+            metadata.AudioFile(dirname='c',
+                               filename='d',
+                               tags=metadata.Tags({})),
         ))
         with self._connection:
             self.assertEqual(
@@ -78,10 +80,15 @@ class DatabaseTest(unittest.TestCase):
 
     def test_insert_files_audio(self):
         self._database.insert_files((
-            metadata.AudioFile(dirname='a', filename='b', tags=(('c', 'd'),)),
+            metadata.AudioFile(dirname='a',
+                               filename='b',
+                               tags=metadata.Tags({'c': ('d',)})),
             metadata.AudioFile(dirname='a',
                                filename='c',
-                               tags=(('a', 'b'), ('a', 'b'), ('c', 'd'))),
+                               tags=metadata.Tags({
+                                   'a': ('b', 'b'),
+                                   'c': ('d',),
+                               })),
         ))
         with self._connection:
             self.assertEqual(

--- a/pepper_music_player/library/scan.py
+++ b/pepper_music_player/library/scan.py
@@ -16,31 +16,19 @@
 import mimetypes
 import os
 import pathlib
-from typing import Generator, Iterable, Tuple
+from typing import Generator
 
 import mutagen
 
 from pepper_music_player import metadata
 
 
-def _read_tags(filename: str) -> Iterable[Tuple[str, str]]:
-    """Reads tags from a file.
-
-    Args:
-        filename: Where to read tags from.
-
-    Returns:
-        See the tags attribute of metadata.AudioFile.
-    """
+def _read_tags(filename: str) -> metadata.Tags:
+    """Returns tags read from a file."""
     file_info = mutagen.File(filename, easy=True)
     if file_info.tags is None:
-        return ()
-    tags_list = []
-    for key, values in file_info.tags.items():
-        for value in values:
-            tags_list.append((key, value))
-    # sorted() is used to make testing easier.
-    return tuple(sorted(tags_list))
+        return metadata.Tags({})
+    return metadata.Tags(file_info.tags)
 
 
 def scan(root_dirname: str) -> Generator[metadata.File, None, None]:

--- a/pepper_music_player/library/scan_test.py
+++ b/pepper_music_player/library/scan_test.py
@@ -61,7 +61,7 @@ class ScanTest(unittest.TestCase):
             {
                 metadata.AudioFile(dirname=str(self._root_dirpath),
                                    filename='foo.flac',
-                                   tags=()),
+                                   tags=metadata.Tags({})),
             },
             frozenset(scan.scan(str(self._root_dirpath))),
         )
@@ -81,12 +81,11 @@ class ScanTest(unittest.TestCase):
                 metadata.AudioFile(
                     dirname=str(self._root_dirpath),
                     filename='foo.flac',
-                    tags=(
-                        ('artists', 'artist1'),
-                        ('artists', 'artist2'),
-                        ('date', '2019-12-21'),
-                        ('title', 'Foo'),
-                    ),
+                    tags=metadata.Tags({
+                        'artists': ('artist1', 'artist2'),
+                        'date': ('2019-12-21',),
+                        'title': ('Foo',),
+                    }),
                 ),
             },
             frozenset(scan.scan(str(self._root_dirpath))),

--- a/pepper_music_player/metadata.py
+++ b/pepper_music_player/metadata.py
@@ -20,7 +20,26 @@ metadata across threads easier.
 """
 
 import dataclasses
-from typing import Iterable, Tuple
+from typing import Iterable, Mapping, Tuple
+
+import frozendict
+
+
+class Tags(frozendict.frozendict, Mapping[str, Tuple[str]]):
+    """Tags, typically from an audio file.
+
+    Note that tags can have multiple values, potentially even multiple identical
+    values. E.g., this is a valid set of tags: {'a': ('b', 'b')}
+    """
+
+    def __init__(self, tags: Mapping[str, Iterable[str]]) -> None:
+        """Initializer.
+
+        Args:
+            tags: Tags to represent, as a mapping from each tag name to all
+                values for that tag.
+        """
+        super().__init__({name: tuple(values) for name, values in tags.items()})
 
 
 @dataclasses.dataclass(frozen=True)
@@ -40,8 +59,6 @@ class AudioFile(File):
     """An audio file.
 
     Attributes:
-        tags: Metadata tags as an iterable of (key, value) tuples. Note that a
-            single key can appear multiple times, potentially even with the same
-            value.
+        tags: Tags from the audio file.
     """
-    tags: Iterable[Tuple[str, str]]
+    tags: Tags

--- a/pepper_music_player/metadata_test.py
+++ b/pepper_music_player/metadata_test.py
@@ -1,0 +1,31 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for pepper_music_player.metadata."""
+
+import unittest
+
+from pepper_music_player import metadata
+
+
+class TagsTest(unittest.TestCase):
+
+    def test_init_converts_values_to_tuple(self):
+        self.assertEqual(
+            ('a', 'b'),
+            metadata.Tags({'foo': ['a', 'b']})['foo'],
+        )
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
+frozendict
 mutagen


### PR DESCRIPTION
I think the mapping interface will be more useful to code outside of
scan.py and library.py. It also opens up the possiblity of custom
methods later, which I think will be necessary.