### PR TITLE
Use counters instead of sets to test collection equality.

### DIFF
--- a/pepper_music_player/library/database_test.py
+++ b/pepper_music_player/library/database_test.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 """Tests for pepper_music_player.library.database."""
 
+import collections
 import os
 import sqlite3
 import tempfile
@@ -71,11 +72,11 @@ class DatabaseTest(unittest.TestCase):
         ))
         with self._connection:
             self.assertEqual(
-                {
+                collections.Counter((
                     ('a', 'b'),
                     ('c', 'd'),
-                },
-                frozenset(
+                )),
+                collections.Counter(
                     self._connection.execute(
                         'SELECT dirname, filename FROM File')),
             )
@@ -101,7 +102,7 @@ class DatabaseTest(unittest.TestCase):
         ))
         with self._connection:
             self.assertEqual(
-                # This uses tuples instead of sets because mock.ANY isn't
+                # This uses tuples instead of Counter because mock.ANY isn't
                 # hashable.
                 (
                     ('a', 'b', mock.ANY),
@@ -117,13 +118,13 @@ class DatabaseTest(unittest.TestCase):
                         """,)),
             )
             self.assertEqual(
-                {
+                collections.Counter((
                     ('a', 'b', 'c', 'd'),
                     ('a', 'c', 'a', 'b'),
                     ('a', 'c', 'a', 'b'),
                     ('a', 'c', 'c', 'd'),
-                },
-                frozenset(
+                )),
+                collections.Counter(
                     self._connection.execute(
                         """
                         SELECT dirname, filename, tag_name, tag_value
@@ -143,11 +144,11 @@ class DatabaseTest(unittest.TestCase):
         ))
         with self._connection:
             self.assertEqual(
-                {
+                collections.Counter((
                     ('dir1', 'file1', 'album', 'album1'),
                     ('dir1', 'file2', 'album', 'album2'),
-                },
-                frozenset(
+                )),
+                collections.Counter(
                     self._connection.execute(
                         """
                         SELECT dirname, filename, tag_name, tag_value
@@ -179,7 +180,7 @@ class DatabaseTest(unittest.TestCase):
         ))
         with self._connection:
             self.assertEqual(
-                (
+                collections.Counter((
                     ('dir1', 'file1', 'album', 'album1'),
                     ('dir1', 'file1', 'common', 'foo'),
                     ('dir1', 'file1', 'common', 'foo'),
@@ -188,15 +189,14 @@ class DatabaseTest(unittest.TestCase):
                     ('dir1', 'file2', 'common', 'foo'),
                     ('dir1', 'file2', 'common', 'foo'),
                     ('dir1', 'file2', 'partially_common', 'common'),
-                ),
-                tuple(
+                )),
+                collections.Counter(
                     self._connection.execute(
                         """
                         SELECT dirname, filename, tag_name, tag_value
                         FROM File
                         JOIN AudioFile ON File.rowid = AudioFile.file_id
                         JOIN AlbumTag USING (album_token)
-                        ORDER BY dirname ASC, filename ASC, tag_name ASC
                         """,)),
             )
 

--- a/pepper_music_player/library/scan_test.py
+++ b/pepper_music_player/library/scan_test.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 """Tests for pepper_music_player.library.scan."""
 
+import collections
 import io
 import pathlib
 import tempfile
@@ -47,23 +48,22 @@ class ScanTest(unittest.TestCase):
         bar.mkdir()
         bar.joinpath('bar1').touch()
         self.assertEqual(
-            {
+            collections.Counter((
                 metadata.File(dirname=str(foo), filename='foo1'),
                 metadata.File(dirname=str(foo), filename='foo2'),
                 metadata.File(dirname=str(bar), filename='bar1'),
-            },
-            frozenset(scan.scan(str(self._root_dirpath))),
+            )),
+            collections.Counter(scan.scan(str(self._root_dirpath))),
         )
 
     def test_parses_empty_tags(self):
         self._root_dirpath.joinpath('foo.flac').write_bytes(_FLAC)
         self.assertEqual(
-            {
-                metadata.AudioFile(dirname=str(self._root_dirpath),
-                                   filename='foo.flac',
-                                   tags=metadata.Tags({})),
-            },
-            frozenset(scan.scan(str(self._root_dirpath))),
+            collections.Counter(
+                (metadata.AudioFile(dirname=str(self._root_dirpath),
+                                    filename='foo.flac',
+                                    tags=metadata.Tags({})),)),
+            collections.Counter(scan.scan(str(self._root_dirpath))),
         )
 
     def test_parses_flac(self):
@@ -77,18 +77,16 @@ class ScanTest(unittest.TestCase):
         self._root_dirpath.joinpath('foo.flac').write_bytes(
             flac_data.getvalue())
         self.assertEqual(
-            {
-                metadata.AudioFile(
-                    dirname=str(self._root_dirpath),
-                    filename='foo.flac',
-                    tags=metadata.Tags({
-                        'artists': ('artist1', 'artist2'),
-                        'date': ('2019-12-21',),
-                        'title': ('Foo',),
-                    }),
-                ),
-            },
-            frozenset(scan.scan(str(self._root_dirpath))),
+            collections.Counter((metadata.AudioFile(
+                dirname=str(self._root_dirpath),
+                filename='foo.flac',
+                tags=metadata.Tags({
+                    'artists': ('artist1', 'artist2'),
+                    'date': ('2019-12-21',),
+                    'title': ('Foo',),
+                }),
+            ),)),
+            collections.Counter(scan.scan(str(self._root_dirpath))),
         )
 
 


### PR DESCRIPTION
This should avoid hiding bugs when one collection has more of a
particular element than the other.