### PR TITLE
Use a custom context manager to handle transactions.

### DIFF
--- a/pepper_music_player/library/database_test.py
+++ b/pepper_music_player/library/database_test.py
@@ -87,6 +87,9 @@ class DatabaseTest(unittest.TestCase):
                 metadata.File(dirname='a', filename='b'),
                 metadata.File(dirname='a', filename='b'),
             ))
+        with self._connection:
+            self.assertFalse(
+                self._connection.execute('SELECT * FROM File').fetchall())
 
     def test_insert_files_audio(self):
         self._database.insert_files((


### PR DESCRIPTION
It seems that the connection's context manager doesn't do anything when
isolation_level is None: https://bugs.python.org/issue16958