### PR TITLE
Use sqlite's write-ahead log mode.

### DIFF
--- a/pepper_music_player/library/database.py
+++ b/pepper_music_player/library/database.py
@@ -113,6 +113,7 @@ class Database:
         if not hasattr(self._local, 'connection'):
             self._local.connection = sqlite3.connect(self._sqlite3_path,
                                                      isolation_level=None)
+            self._local.connection.execute('PRAGMA journal_mode=WAL')
         return self._local.connection
 
     @contextlib.contextmanager


### PR DESCRIPTION
From reading https://www.sqlite.org/wal.html, it looks like it's
probably a good idea for this sort of app. Allowing reads while one
connection is writing seems like it will prevent the app from locking up
which (re)scanning the library.