### PR TITLE
Make album_token an attribute instead of a method.

### DIFF
--- a/pepper_music_player/library/database.py
+++ b/pepper_music_player/library/database.py
@@ -164,7 +164,7 @@ class Database:
             """,
             {
                 'file_id': file_id,
-                'album_token': file_info.album_token(),
+                'album_token': file_info.album_token,
             },
         )
         for tag_name, tag_values in file_info.tags.items():

--- a/pepper_music_player/metadata.py
+++ b/pepper_music_player/metadata.py
@@ -91,20 +91,23 @@ class AudioFile(File):
 
     Attributes:
         tags: Tags from the audio file.
+        album_token: Opaque token that identifies the album for this file. If
+            two files are on the same album, they should have the same token;
+            otherwise, they should have different tokens. Callers should not
+            rely on any other property of the token.
     """
     tags: Tags
+    album_token: str = dataclasses.field(init=False, repr=False)
 
-    def album_token(self) -> str:
-        """Returns an opaque token that identifies the album for this file.
-
-        If two files are on the same album, they should have the same token;
-        otherwise, they should have different tokens. Callers should not rely on
-        any other property of the token.
-        """
-        # TODO(dseomn): Figure out if this needs to be versioned somehow.
-        return repr((
-            self.dirname,
-            self.tags.get(TagName.ALBUM, ()),
-            self.tags.get(TagName.ALBUMARTIST, ()),
-            self.tags.get(TagName.MUSICBRAINZ_ALBUMID, ()),
-        ))
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self,
+            'album_token',
+            # TODO(dseomn): Figure out if this needs to be versioned somehow.
+            repr((
+                self.dirname,
+                self.tags.get(TagName.ALBUM, ()),
+                self.tags.get(TagName.ALBUMARTIST, ()),
+                self.tags.get(TagName.MUSICBRAINZ_ALBUMID, ()),
+            )),
+        )

--- a/pepper_music_player/metadata_test.py
+++ b/pepper_music_player/metadata_test.py
@@ -50,12 +50,12 @@ class AudioFileTest(unittest.TestCase):
                 dirname='/a',
                 filename='b',
                 tags=metadata.Tags({'album': ('a',)}),
-            ).album_token(),
+            ).album_token,
             metadata.AudioFile(
                 dirname='/a',
                 filename='c',
                 tags=metadata.Tags({'album': ('a',)}),
-            ).album_token(),
+            ).album_token,
         )
 
     def test_album_token_different(self):
@@ -64,12 +64,12 @@ class AudioFileTest(unittest.TestCase):
                 dirname='/a',
                 filename='b',
                 tags=metadata.Tags({'album': ('a',)}),
-            ).album_token(),
+            ).album_token,
             metadata.AudioFile(
                 dirname='/a',
                 filename='c',
                 tags=metadata.Tags({'album': ('d',)}),
-            ).album_token(),
+            ).album_token,
         )
 
 


### PR DESCRIPTION
I'm now planning to use this as the main way a frontend keeps track of
albums (and later, add another opaque token for tracks), so it makes
more sense to compute it once per object.