### PR TITLE
Add a track token.

### DIFF
--- a/pepper_music_player/library/database.py
+++ b/pepper_music_player/library/database.py
@@ -53,8 +53,10 @@ _SCHEMA_CREATE = (
     """
     CREATE TABLE AudioFile (
         file_id INTEGER NOT NULL REFERENCES File (rowid) ON DELETE CASCADE,
+        token TEXT NOT NULL,
         album_token TEXT NOT NULL,
-        PRIMARY KEY (file_id)
+        PRIMARY KEY (file_id),
+        UNIQUE (token)
     )
     """,
     'CREATE INDEX AudioFile_AlbumIndex ON AudioFile (album_token)',
@@ -159,11 +161,12 @@ class Database:
         """
         self._connection.execute(
             """
-            INSERT INTO AudioFile (file_id, album_token)
-            VALUES (:file_id, :album_token)
+            INSERT INTO AudioFile (file_id, token, album_token)
+            VALUES (:file_id, :token, :album_token)
             """,
             {
                 'file_id': file_id,
+                'token': file_info.token,
                 'album_token': file_info.album_token,
             },
         )

--- a/pepper_music_player/library/database_test.py
+++ b/pepper_music_player/library/database_test.py
@@ -41,7 +41,10 @@ class DatabaseTest(unittest.TestCase):
                 'INSERT INTO File (dirname, filename) VALUES ("a", "b")'
             ).lastrowid
             self._connection.execute(
-                'INSERT INTO AudioFile (file_id, album_token) VALUES (?, "a")',
+                """
+                INSERT INTO AudioFile (file_id, token, album_token)
+                VALUES (?, "b", "a")
+                """,
                 (file_id,),
             )
             self._connection.execute(
@@ -108,13 +111,13 @@ class DatabaseTest(unittest.TestCase):
                 # This uses tuples instead of Counter because mock.ANY isn't
                 # hashable.
                 (
-                    ('a', 'b', mock.ANY),
-                    ('a', 'c', mock.ANY),
+                    ('a', 'b', mock.ANY, mock.ANY),
+                    ('a', 'c', mock.ANY, mock.ANY),
                 ),
                 tuple(
                     self._connection.execute(
                         """
-                        SELECT dirname, filename, album_token
+                        SELECT dirname, filename, token, album_token
                         FROM File
                         JOIN AudioFile ON File.rowid = AudioFile.file_id
                         ORDER BY dirname ASC, filename ASC

--- a/pepper_music_player/metadata.py
+++ b/pepper_music_player/metadata.py
@@ -91,15 +91,26 @@ class AudioFile(File):
 
     Attributes:
         tags: Tags from the audio file.
+        token: Opaque token that identifies this track.
         album_token: Opaque token that identifies the album for this file. If
             two files are on the same album, they should have the same token;
             otherwise, they should have different tokens. Callers should not
             rely on any other property of the token.
     """
     tags: Tags
+    token: str = dataclasses.field(init=False, repr=False)
     album_token: str = dataclasses.field(init=False, repr=False)
 
     def __post_init__(self) -> None:
+        object.__setattr__(
+            self,
+            'token',
+            repr((
+                'track/v1alpha',  # TODO(#20): Change to v1.
+                self.dirname,
+                self.filename,
+            )),
+        )
         object.__setattr__(
             self,
             'album_token',

--- a/pepper_music_player/metadata_test.py
+++ b/pepper_music_player/metadata_test.py
@@ -44,6 +44,20 @@ class TagsTest(unittest.TestCase):
 
 class AudioFileTest(unittest.TestCase):
 
+    def test_token_different(self):
+        self.assertNotEqual(
+            metadata.AudioFile(
+                dirname='/a',
+                filename='b',
+                tags=metadata.Tags({}),
+            ).token,
+            metadata.AudioFile(
+                dirname='/a',
+                filename='c',
+                tags=metadata.Tags({}),
+            ).token,
+        )
+
     def test_album_token_same(self):
         self.assertEqual(
             metadata.AudioFile(


### PR DESCRIPTION
This is what other code should use to identify tracks. (E.g., a queue
can store these tokens in its database so that when the app restarts,
the same tracks are enqueued.)