### PR TITLE
Make classes for opaque tokens.

### DIFF
--- a/pepper_music_player/library/database.py
+++ b/pepper_music_player/library/database.py
@@ -170,8 +170,8 @@ class Database:
             """,
             {
                 'file_id': file_id,
-                'token': file_info.token,
-                'album_token': file_info.album_token,
+                'token': str(file_info.token),
+                'album_token': str(file_info.album_token),
             },
         )
         for tag_name, tag_values in file_info.tags.items():

--- a/pepper_music_player/metadata_test.py
+++ b/pepper_music_player/metadata_test.py
@@ -42,6 +42,12 @@ class TagsTest(unittest.TestCase):
         self.assertIn(metadata.TagName.ALBUM, metadata.Tags({'album': ('a',)}))
 
 
+class TokenTest(unittest.TestCase):
+
+    def test_token_str(self):
+        self.assertEqual('foo', str(metadata.Token('foo')))
+
+
 class AudioFileTest(unittest.TestCase):
 
     def test_token_different(self):


### PR DESCRIPTION
1. This should help the type checker catch bugs if the wrong type of
   token is used.
2. It makes it much more obvious when the tokens are being used for
   anything other than comparing equality.
3. It allows functions to take multiple types of tokens, and use
   isinstance() to decide what to do based on the type of token given.