### PR TITLE
Add a helper to load Gtk.Builder objects from python resources.

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -30,10 +30,26 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v1
+    - name: Install system dependencies (macOS)
+      if: runner.os == 'macOS'
+      run: |
+        brew install \
+          gtk+3 \
+          pygobject3
+    - name: Install system dependencies (Linux)
+      if: runner.os == 'Linux'
+      run: |
+        sudo apt-get install \
+          gir1.2-gtk-3.0 \
+          libgirepository1.0-dev
     - uses: actions/setup-python@v1
       with:
         python-version: ${{ matrix.python-version }}
-    - name: Install dependencies
+    - name: Install Python dependencies
+      env:
+        # Brew on macOS outputs a message to set these environment variables.
+        LDFLAGS: '-L/usr/local/opt/libffi/lib'
+        PKG_CONFIG_PATH: '/usr/local/opt/libffi/lib/pkgconfig'
       run: |
         python -m pip install --upgrade pip
         pip install -r requirements.txt
@@ -56,7 +72,14 @@ jobs:
       run: |
         pip install pytype
         pytype
-    - name: Test
+    - name: Test (xvfb graphics)
+      if: runner.os == 'Linux'
+      run: |
+        sudo apt-get install xvfb
+        pip install pytest pytest-cov
+        xvfb-run pytest --cov=. --cov-branch --cov-report=term-missing
+    - name: Test (native graphics)
+      if: runner.os != 'Linux'
       run: |
         pip install pytest pytest-cov
         pytest --cov=. --cov-branch --cov-report=term-missing

--- a/README.md
+++ b/README.md
@@ -47,7 +47,10 @@ None yet.
 
 ```
 sudo apt install \
+    gir1.2-gtk-3.0 \
+    libgirepository1.0-dev \
     python3-frozendict \
+    python3-gi \
     python3-mutagen
 ```
 

--- a/pepper_music_player/ui/__init__.py
+++ b/pepper_music_player/ui/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/pepper_music_player/ui/load.py
+++ b/pepper_music_player/ui/load.py
@@ -1,0 +1,34 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pkgutil
+
+import gi
+gi.require_version('Gtk', '3.0')
+from gi.repository import Gtk
+
+
+def builder_from_resource(package: str, resource: str) -> Gtk.Builder:
+    """Returns a builder from a python resource.
+
+    Args:
+        package: Package to load from, e.g., 'pepper_music_player.ui'.
+        resource: Filename within the package.
+    """
+    resource_bytes = pkgutil.get_data(package, resource)
+    if resource_bytes is None:
+        raise RuntimeError("The package loader doesn't support get_data().")
+    builder = Gtk.Builder()
+    builder.add_from_string(resource_bytes.decode())
+    return builder

--- a/pepper_music_player/ui/load_test.glade
+++ b/pepper_music_player/ui/load_test.glade
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Generated with glade 3.22.1 
+
+Copyright 2020 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License"); 
+you may not use this file except in compliance with the License. 
+You may obtain a copy of the License at 
+
+    http://www.apache.org/licenses/LICENSE-2.0 
+
+Unless required by applicable law or agreed to in writing, software 
+distributed under the License is distributed on an "AS IS" BASIS, 
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
+See the License for the specific language governing permissions and 
+limitations under the License.
+
+-->
+<interface>
+  <requires lib="gtk+" version="3.20"/>
+  <!-- interface-license-type apache2 -->
+  <!-- interface-copyright 2020 Google LLC -->
+  <object class="GtkWindow" id="test_object">
+    <child>
+      <placeholder/>
+    </child>
+    <child>
+      <placeholder/>
+    </child>
+  </object>
+</interface>

--- a/pepper_music_player/ui/load_test.py
+++ b/pepper_music_player/ui/load_test.py
@@ -1,0 +1,29 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+from pepper_music_player.ui import load
+
+
+class BuilderFromResourceTest(unittest.TestCase):
+
+    def test_returns_builder(self):
+        builder = load.builder_from_resource('pepper_music_player.ui',
+                                             'load_test.glade')
+        self.assertTrue(builder.get_object('test_object'))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
+PyGObject
 frozendict
 mutagen


### PR DESCRIPTION
Unfortunately, I'm not sure the dependencies in the README are correct.