### PR TITLE
Ignore filenames than end in '~'.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /.coverage
 /.pytype
 
+*~
 __pycache__/


### PR DESCRIPTION
Glade seems to output a bunch of these.