### PR TITLE
Use different test artifact directories for different environments.

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -88,5 +88,5 @@ jobs:
     - uses: actions/upload-artifact@v1
       if: always()
       with:
-        name: test-artifacts
+        name: test-artifacts-${{ matrix.os }}-python${{ matrix.python-version }}
         path: ${{ env.TEST_ARTIFACT_DIR }}


### PR DESCRIPTION
It looks like GitHub doesn't show per-environment artifacts, so this
makes it possible to see the artifacts from each environment.