### PR TITLE
Create $TEST_ARTIFACT_DIR regardless of what exists already.

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -32,7 +32,6 @@ jobs:
       TEST_ARTIFACT_DIR: ${{ github.workspace }}/test-artifacts
     steps:
     - uses: actions/checkout@v1
-    - run: mkdir "$TEST_ARTIFACT_DIR"
     - name: Install system dependencies (macOS)
       if: runner.os == 'macOS'
       run: |


### PR DESCRIPTION
72a1ea5bd9658dd4c66381a07727fd24306918bb broke the test action because
`mkdir` fails if the directory already exists. This fixes that.