### PR TITLE
Update the APT database before installing things.

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -45,6 +45,7 @@ jobs:
     - name: Install system dependencies (Linux)
       if: runner.os == 'Linux'
       run: |
+        sudo apt-get update
         sudo apt-get install \
           gir1.2-gst-plugins-base-1.0 \
           gir1.2-gstreamer-1.0 \


### PR DESCRIPTION
https://github.com/dseomn/pepper-music-player/runs/420969528?check_suite_focus=true
failed with 404 Not Found when trying to download some packages.