### PR TITLE
Make Codecov less strict.

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,22 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+coverage:
+  status:
+    project:
+      default:
+        target: 95%
+    patch:
+      default:
+        informational: true


### PR DESCRIPTION
I think coverage is more useful as a project-wide target and as an
informational tool for authors and reviewers, than as a strict check on
commits or PRs.