### PR TITLE
Optimize when Percy is used.

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -15,7 +15,7 @@
 on:
   push: {}
   schedule:
-  - cron: '47 8 * * *'
+  - cron: '47 8 * * 6'
 
 jobs:
   test:
@@ -114,7 +114,12 @@ jobs:
         path: ${{ env.TEST_ARTIFACT_DIR }}
 
   percy:
-    if: github.event_name == 'schedule'
+    if: >-
+      github.event_name == 'schedule' ||
+      (
+        github.event_name == 'push' &&
+        contains(join(github.event.commits.*.message), 'Visual-Testing: yes')
+      )
     needs: test
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
1. Reduce the scheduled frequency to once per week to save Percy
   resources when there's nothing interesting for it to do.
2. Make it possible to upload to Percy on demand when there is something
   useful for it to do.

Visual-Testing: yes