### PR TITLE
Revert "Skip test on macOS because of gstreamer bug."

### DIFF
--- a/pepper_music_player/player/player_test.py
+++ b/pepper_music_player/player/player_test.py
@@ -16,7 +16,6 @@
 import datetime
 import operator
 import os
-import sys
 import tempfile
 import time
 import unittest
@@ -354,12 +353,6 @@ class PlayerTest(unittest.TestCase):
         self._player.previous()
         self.assertEqual(_AUDIO_ZEROES, self._all_audio()[-len(_AUDIO_ZEROES):])
 
-    # TODO(https://gitlab.freedesktop.org/gstreamer/gstreamer/-/issues/616):
-    # Don't skip this test.
-    @unittest.skipIf(
-        sys.platform.startswith('darwin'),
-        'https://gitlab.freedesktop.org/gstreamer/gstreamer/-/issues/616',
-    )
     def test_logs_and_stops_on_error(self):
         tempdir = tempfile.TemporaryDirectory()
         self.addCleanup(tempdir.cleanup)


### PR DESCRIPTION
The bug was fixed in gstreamer 1.18.1.

This reverts commit fda9dae0a01607efc919917eaf942c0a574cc8a5.